### PR TITLE
Replaced smart quotes in Podfile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,4 +2,4 @@ source 'https://github.com/CocoaPods/Specs.git'
 link_with ['Microsoft Tasks']
 xcodeproj 'Microsoft Tasks B2C'
 
-pod 'ADALiOS', :git => 'https://github.com/AzureAD/azure-activedirectory-library-for-objc', :branch => ‘real_b2c’
+pod 'ADALiOS', :git => 'https://github.com/AzureAD/azure-activedirectory-library-for-objc', :branch => 'real_b2c'


### PR DESCRIPTION
Replaced smart quotes in podfile to remove warning received when installing Pods
